### PR TITLE
fix: correct module name to BMad Game Dev Studio

### DIFF
--- a/src/module.yaml
+++ b/src/module.yaml
@@ -1,5 +1,5 @@
 code: gds
-name: "BMGD: BMad Game Development"
+name: "BMGD: BMad Game Dev Studio"
 header: "BMad Game Development Studio Module"
 subheader: ""
 default_selected: false


### PR DESCRIPTION
## Summary
- The `name` field in `src/module.yaml` says "BMGD: BMad Game Development" but the README refers to the module as "BMad Game Dev Studio (BMGD)"
- This PR corrects the module name to match the README

## Changes
- `src/module.yaml`: `name` field updated from "BMGD: BMad Game Development" to "BMGD: BMad Game Dev Studio"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated module branding from "BMGD: BMad Game Development" to "BMGD: BMad Game Dev Studio"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->