### PR TITLE
refactor(catalog): rename after/before to preceded-by/followed-by

### DIFF
--- a/src/module-help.csv
+++ b/src/module-help.csv
@@ -1,4 +1,4 @@
-module,skill,display-name,menu-code,description,action,args,phase,after,before,required,output-location,outputs
+module,skill,display-name,menu-code,description,action,args,phase,preceded-by,followed-by,required,output-location,outputs
 Game Dev Studio,_meta,,,,,,,,,false,https://game-dev-studio-docs.bmad-method.org/llms.txt,
 Game Dev Studio,gds-document-project,Document Project,DP,Analyze an existing game project to produce useful documentation.,,,anytime,,,false,project_knowledge,project documentation
 Game Dev Studio,gds-quick-prototype,Quick Prototype,QP,Rapid game prototyping to test mechanics and ideas quickly.,,,anytime,,,false,,


### PR DESCRIPTION
## Summary

Header-only rename of `module-help.csv` columns 9 and 10 from `after`/`before` to `preceded-by`/`followed-by`, aligning this module with the canonical schema shipped in bmad-code-org/BMAD-METHOD#2360.

## Why

The bare prepositions had no subject anchor — "X has Y in its `after` column" reads plausibly as either "Y comes after X" or "X comes after Y". An LLM consumer recently flipped the direction because of it; passive-voice participles ("X is preceded by Y") force a single reading.

## Scope

- Single line changed (header only) in `module-help.csv`.
- Data rows are positionally identical and the upstream merger loads them unchanged regardless of header — this is purely a label rename.
- Without this rename, BMAD-METHOD v6.6.1+ installs emit an advisory warning naming this module on every install.

## Test plan

- [x] `npm ci && npm test` passes locally
- [ ] Reviewer: confirm no local consumer in this repo reads the CSV by column name (none expected — the merger is in BMAD-METHOD)
