### PR TITLE
fix: invoke Python scripts with uv run, drop the Python browser opener

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/bmad-game-dev-studio?color=blue&label=version)](https://www.npmjs.com/package/bmad-game-dev-studio)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Python Version](https://img.shields.io/badge/python-%3E%3D3.10-blue?logo=python&logoColor=white)](https://www.python.org)
+[![Python Version](https://img.shields.io/badge/python-%3E%3D3.11-blue?logo=python&logoColor=white)](https://www.python.org)
 [![uv](https://img.shields.io/badge/uv-package%20manager-blueviolet?logo=uv)](https://docs.astral.sh/uv/)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289da?logo=discord&logoColor=white)](https://discord.gg/gk8jAdXWmj)
 

--- a/src/agents/gds-agent-game-architect/SKILL.md
+++ b/src/agents/gds-agent-game-architect/SKILL.md
@@ -20,7 +20,7 @@ You are Cloud Dragonborn, the Game Architect. You design scalable game architect
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/agents/gds-agent-game-designer/SKILL.md
+++ b/src/agents/gds-agent-game-designer/SKILL.md
@@ -20,7 +20,7 @@ You are Samus Shepard, the Game Designer. You drive creative vision, game design
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/agents/gds-agent-game-dev/SKILL.md
+++ b/src/agents/gds-agent-game-dev/SKILL.md
@@ -22,7 +22,7 @@ You are Link Freeman, the Game Developer. You implement features, execute dev st
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/agents/gds-agent-game-solo-dev/SKILL.md
+++ b/src/agents/gds-agent-game-solo-dev/SKILL.md
@@ -20,7 +20,7 @@ You are Indie, the Game Solo Dev. You ship complete games from concept to launch
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/agents/gds-agent-tech-writer/SKILL.md
+++ b/src/agents/gds-agent-tech-writer/SKILL.md
@@ -20,7 +20,7 @@ You are Paige, the Technical Writer. You transform complex game development conc
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/1-preproduction/gds-brainstorm-game/SKILL.md
+++ b/src/workflows/1-preproduction/gds-brainstorm-game/SKILL.md
@@ -22,7 +22,7 @@ description: 'Facilitate game brainstorming sessions with game-specific techniqu
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/1-preproduction/gds-brainstorm-game/steps/step-04-complete.md
+++ b/src/workflows/1-preproduction/gds-brainstorm-game/steps/step-04-complete.md
@@ -277,6 +277,6 @@ This step-file architecture ensures consistent, creative brainstorming with user
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/1-preproduction/gds-create-game-brief/SKILL.md
+++ b/src/workflows/1-preproduction/gds-create-game-brief/SKILL.md
@@ -15,7 +15,7 @@ At the opening greeting, let the user know they can invoke `bmad-party-mode` for
 
 ## On Activation
 
-1. Resolve customization: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`. On failure, read `{skill-root}/customize.toml` directly and use defaults.
+1. Resolve customization: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`. On failure, read `{skill-root}/customize.toml` directly and use defaults.
 2. Execute each entry in `{workflow.activation_steps_prepend}` in order.
 3. Treat every entry in `{workflow.persistent_facts}` as foundational context for the rest of the run. Entries prefixed `file:` are paths or globs under `{project-root}` — load the referenced contents as facts. All other entries are facts verbatim.
 4. `{workflow.external_sources}` is an org-configured registry of internal tools (knowledge bases, MCP tools); consult them alongside generic web research on the same triggers in `## Discovery`, org tools preferred when their directive matches. If a named tool is unavailable at runtime, fall back to standard behavior and note the gap when relevant.

--- a/src/workflows/1-preproduction/research/gds-domain-research/SKILL.md
+++ b/src/workflows/1-preproduction/research/gds-domain-research/SKILL.md
@@ -20,7 +20,7 @@ description: 'Conduct game domain and industry research. Use when the user says 
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/1-preproduction/research/gds-domain-research/domain-steps/step-06-research-synthesis.md
+++ b/src/workflows/1-preproduction/research/gds-domain-research/domain-steps/step-06-research-synthesis.md
@@ -446,6 +446,6 @@ Congratulations on completing comprehensive game domain research!
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/2-design/gds-create-narrative/SKILL.md
+++ b/src/workflows/2-design/gds-create-narrative/SKILL.md
@@ -22,7 +22,7 @@ description: 'Create comprehensive narrative documentation with story structure 
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/2-design/gds-create-narrative/steps/step-11-complete.md
+++ b/src/workflows/2-design/gds-create-narrative/steps/step-11-complete.md
@@ -333,6 +333,6 @@ This step-file architecture ensures consistent, thorough narrative design with u
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/2-design/gds-gdd/SKILL.md
+++ b/src/workflows/2-design/gds-gdd/SKILL.md
@@ -21,7 +21,7 @@ At the opening greeting, let the user know they can invoke the skills `bmad-part
 
 ## On Activation
 
-1. Resolve customization: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`. On failure, surface the diagnostic and halt.
+1. Resolve customization: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`. On failure, surface the diagnostic and halt.
 2. Execute each entry in `{workflow.activation_steps_prepend}` in order.
 3. Treat every entry in `{workflow.persistent_facts}` as foundational context. Entries prefixed `file:` are paths or globs under `{project-root}` — load their contents as facts. All others are facts verbatim.
 4. Note `{workflow.external_sources}` as a registry to consult on demand when the conversation surfaces a relevant need. Do not query preemptively. If a named tool is unavailable at runtime, fall back to standard behavior and note the gap.

--- a/src/workflows/2-design/gds-gdd/references/validation-render.md
+++ b/src/workflows/2-design/gds-gdd/references/validation-render.md
@@ -44,7 +44,7 @@ Per-finding fields:
 After the subagent writes findings:
 
 ```bash
-python3 {skill-root}/scripts/render-validation-html.py \
+uv run {skill-root}/scripts/render-validation-html.py \
   --findings {doc_workspace}/validation-findings.json \
   --template {workflow.validation_report_template} \
   --output {doc_workspace}/validation-report.html \

--- a/src/workflows/2-design/gds-prd/SKILL.md
+++ b/src/workflows/2-design/gds-prd/SKILL.md
@@ -31,7 +31,7 @@ You are a facilitator, not a form. The user is the author; you are the structure
 
 ## On Activation
 
-1. Resolve customization: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`. On failure, read `{skill-root}/customize.toml` directly and proceed with its values.
+1. Resolve customization: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`. On failure, read `{skill-root}/customize.toml` directly and proceed with its values.
 2. Execute each entry in `{workflow.activation_steps_prepend}` in order.
 3. Treat every entry in `{workflow.persistent_facts}` as foundational context. Entries prefixed `file:` are paths or globs under `{project-root}` — load their contents as facts. All others are facts verbatim.
 4. Note `{workflow.external_sources}` as a registry to consult on demand when the conversation surfaces a relevant need. Do not query preemptively. If a named tool is unavailable at runtime, fall back to standard behavior and note the gap.

--- a/src/workflows/2-design/gds-prd/references/validate.md
+++ b/src/workflows/2-design/gds-prd/references/validate.md
@@ -40,13 +40,13 @@ After the subagent writes findings, the parent fills `{workflow.validation_repor
 
 Grade derivation: *Excellent* = no fails, no high/critical findings · *Good* = no critical findings, at most minor fails · *Fair* = any high finding or several fails · *Poor* = any critical finding.
 
-For interactive runs, open the HTML:
+For interactive runs, open the HTML with the platform opener — `open` on macOS, `xdg-open` on Linux, `start ""` on Windows — double-quoting the path:
 
 ```bash
-python3 -c "import webbrowser, pathlib; webbrowser.open(pathlib.Path('{doc_workspace}/validation-report.html').resolve().as_uri())"
+open "{doc_workspace}/validation-report.html"
 ```
 
-Skip the open step in headless mode (see `references/headless.md`). Re-running validation overwrites the report in place.
+If the command fails, don't retry with another opener: tell the user the file path and move on. Skip the open step in headless mode (see `references/headless.md`). Re-running validation overwrites the report in place.
 
 ## Close
 

--- a/src/workflows/2-design/gds-ux/SKILL.md
+++ b/src/workflows/2-design/gds-ux/SKILL.md
@@ -33,7 +33,7 @@ UX may lead, follow, or stand alone. Inherit `sources:` by reference; the spines
 
 ## On Activation
 
-1. Resolve customization: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`. On failure, read `{skill-root}/customize.toml` directly and use defaults.
+1. Resolve customization: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`. On failure, read `{skill-root}/customize.toml` directly and use defaults.
 2. Run `{workflow.activation_steps_prepend}`. Treat `{workflow.persistent_facts}` as foundational context (entries prefixed `file:` are loaded). `{workflow.external_sources}` is an org-configured registry of internal tools; consult them alongside generic web research on the same triggers, org tools preferred when their directive matches.
 3. Load `{project-root}/_bmad/gds/config.yaml` (+ `config.user.yaml` if present). Resolve `{user_name}`, `{communication_language}`, `{document_output_language}`, `{planning_artifacts}`, `{project_name}`, `{date}`. Missing keys → neutral defaults; never block.
 4. If headless, follow `references/headless.md` for the whole run. Otherwise greet the user **by name** using `{user_name}` and **in their language** using `{communication_language}` — and stay in `{communication_language}` for every turn. In the greeting, let the user know `bmad-party-mode` and `bmad-advanced-elicitation` are always available. Then scan for misroute on the first message: PRD → `gds-prd`; architecture → `gds-game-architecture`; narrative → `gds-create-narrative`; GDD → `gds-gdd`.

--- a/src/workflows/2-design/gds-ux/assets/color-themes.md
+++ b/src/workflows/2-design/gds-ux/assets/color-themes.md
@@ -6,4 +6,4 @@ Each variation: header (name + one-line emotional register), token chips for eve
 
 Inline CSS only, system font stack, no JS, no network. Document concrete hex values in `<style>` comments per variation so the user can lift them if they pick that theme. The spine itself stays semantic.
 
-Return to the parent: file path, one-line per variation, mode coverage. Do not dump HTML into the parent context. If interactive, open the file with `python3 -c "import webbrowser, pathlib; webbrowser.open(pathlib.Path('PATH').resolve().as_uri())"`.
+Return to the parent: file path, one-line per variation, mode coverage. Do not dump HTML into the parent context. If interactive, open the file with the platform opener — `open "PATH"` on macOS, `xdg-open` on Linux, `start ""` on Windows, path always double-quoted. On failure, give the user the path instead.

--- a/src/workflows/2-design/gds-ux/references/creative-tools.md
+++ b/src/workflows/2-design/gds-ux/references/creative-tools.md
@@ -16,4 +16,4 @@ Every renderer writes to `{doc_workspace}/.working/` with a descriptive filename
 
 The parent passes the subagent: current `.decision-log.md`, relevant prior `.working/` captures, the user's stated intent for this pass, the output path. The subagent writes its artifact under `.working/` and returns ONLY a compact summary (file path, one line per variant, mode coverage). Parent never holds the full payload.
 
-For HTML, open in browser when interactive: `python3 -c "import webbrowser, pathlib; webbrowser.open(pathlib.Path('PATH').resolve().as_uri())"`. Skip in headless.
+For HTML, open in the browser when interactive with the platform opener — `open "PATH"` on macOS, `xdg-open` on Linux, `start ""` on Windows, path always double-quoted. On failure, give the user the path instead. Skip in headless.

--- a/src/workflows/2-design/gds-ux/references/validate.md
+++ b/src/workflows/2-design/gds-ux/references/validate.md
@@ -69,7 +69,7 @@ Under Validate intent, after every reviewer returns, render one consolidated rep
 2. Fill `{workflow.validation_report_template}`. No overall grade — the per-category verdicts and severity counts already say what's true. Synthesis paragraph lifts the rubric's overall verdict; add a second if extra reviewers shift the picture. One section per rubric category (open if thin / broken), one per extra reviewer (closed, adversarial voice preserved).
 3. Write `{doc_workspace}/validation-report.html`.
 4. Write the Markdown twin `{doc_workspace}/validation-report.md` — same content grouped by severity.
-5. Open HTML: `python3 -c "import webbrowser, pathlib; webbrowser.open(pathlib.Path('{doc_workspace}/validation-report.html').resolve().as_uri())"`. Skip headless.
+5. Open HTML with the platform opener — `open "{doc_workspace}/validation-report.html"` on macOS, `xdg-open` on Linux, `start ""` on Windows, path always double-quoted. On failure, give the user the path instead. Skip headless.
 
 Re-running overwrites the consolidated report; individual `review-*.md` files persist.
 

--- a/src/workflows/3-technical/gds-check-implementation-readiness/SKILL.md
+++ b/src/workflows/3-technical/gds-check-implementation-readiness/SKILL.md
@@ -20,7 +20,7 @@ description: 'Verify GDD, UX, Architecture, and Epics alignment before productio
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/3-technical/gds-check-implementation-readiness/steps/step-06-final-assessment.md
+++ b/src/workflows/3-technical/gds-check-implementation-readiness/steps/step-06-final-assessment.md
@@ -130,6 +130,6 @@ Implementation Readiness complete. Invoke the `gds-help` skill.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/3-technical/gds-create-epics-and-stories/SKILL.md
+++ b/src/workflows/3-technical/gds-create-epics-and-stories/SKILL.md
@@ -22,7 +22,7 @@ description: 'Create Epics and Stories from GDD requirements for development. Us
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/3-technical/gds-create-epics-and-stories/steps/step-04-final-validation.md
+++ b/src/workflows/3-technical/gds-create-epics-and-stories/steps/step-04-final-validation.md
@@ -156,6 +156,6 @@ Upon Completion of task output: offer to answer any questions about the Epics an
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/3-technical/gds-game-architecture/SKILL.md
+++ b/src/workflows/3-technical/gds-game-architecture/SKILL.md
@@ -22,7 +22,7 @@ description: 'Design scale-adaptive game architecture with engine systems and ne
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/3-technical/gds-game-architecture/steps/step-09-complete.md
+++ b/src/workflows/3-technical/gds-game-architecture/steps/step-09-complete.md
@@ -376,6 +376,6 @@ This step-file architecture ensures consistent, thorough architecture creation w
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/3-technical/gds-generate-project-context/SKILL.md
+++ b/src/workflows/3-technical/gds-generate-project-context/SKILL.md
@@ -22,7 +22,7 @@ description: 'Create optimized project-context.md for AI agent consistency. Use 
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/3-technical/gds-generate-project-context/steps/step-03-complete.md
+++ b/src/workflows/3-technical/gds-generate-project-context/steps/step-03-complete.md
@@ -281,6 +281,6 @@ The project context file serves as the critical "rules of the road" that agents 
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/4-production/gds-code-review/SKILL.md
+++ b/src/workflows/4-production/gds-code-review/SKILL.md
@@ -20,7 +20,7 @@ description: 'Review code changes adversarially using parallel review layers (Bl
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/4-production/gds-code-review/steps/step-04-present.md
+++ b/src/workflows/4-production/gds-code-review/steps/step-04-present.md
@@ -127,6 +127,6 @@ Present the user with follow-up options:
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/4-production/gds-correct-course/SKILL.md
+++ b/src/workflows/4-production/gds-correct-course/SKILL.md
@@ -20,7 +20,7 @@ description: 'Manage significant changes during sprint execution. Use when the u
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -309,7 +309,7 @@ Activation is complete. If `activation_steps_prepend` or `activation_steps_appen
 <action>Report workflow completion to user with personalized message: "Correct Course workflow complete, {user_name}!"</action>
 <action>Remind user of success criteria and next steps for Developer agent</action>
 
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/workflows/4-production/gds-create-story/SKILL.md
+++ b/src/workflows/4-production/gds-create-story/SKILL.md
@@ -52,7 +52,7 @@ description: 'Creates a dedicated story file with all the context the agent will
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -450,7 +450,7 @@ Activation is complete. If `activation_steps_prepend` or `activation_steps_appen
 
     **The developer now has everything needed for flawless implementation!**
   </output>
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/workflows/4-production/gds-dev-story/SKILL.md
+++ b/src/workflows/4-production/gds-dev-story/SKILL.md
@@ -39,7 +39,7 @@ description: 'Execute story implementation following a context filled story spec
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -513,7 +513,7 @@ Activation is complete. If `activation_steps_prepend` or `activation_steps_appen
       <action>Suggest checking {sprint_status} to see project progress</action>
     </check>
     <action>Remain flexible - allow user to choose their own path or ask for other assistance</action>
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/workflows/4-production/gds-investigate/SKILL.md
+++ b/src/workflows/4-production/gds-investigate/SKILL.md
@@ -52,7 +52,7 @@ After every outcome, present what was learned and pause for the user before cont
 
 ### Step 1: Resolve the workflow block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 If the script fails, stop and surface the error.
 

--- a/src/workflows/4-production/gds-retrospective/SKILL.md
+++ b/src/workflows/4-production/gds-retrospective/SKILL.md
@@ -63,7 +63,7 @@ description: 'Post-epic review to extract lessons and assess success. Use when t
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -1499,7 +1499,7 @@ Alice (Product Owner): "See you at epic planning!"
 Charlie (Senior Dev): "Time to knock out that prep work."
 
 </output>
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/workflows/4-production/gds-sprint-planning/SKILL.md
+++ b/src/workflows/4-production/gds-sprint-planning/SKILL.md
@@ -43,7 +43,7 @@ description: 'Generate sprint status tracking from epics. Use when the user says
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -255,7 +255,7 @@ development_status:
 2. Use this file to track development progress
 3. Agents will update statuses as they work
 4. Re-run this workflow to refresh auto-detected statuses
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/workflows/4-production/gds-sprint-status/SKILL.md
+++ b/src/workflows/4-production/gds-sprint-status/SKILL.md
@@ -37,7 +37,7 @@ description: 'Summarize sprint status and surface risks. Use when the user says 
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -228,7 +228,7 @@ If the command targets a story, set `story_key={{next_story_id}}` when prompted.
     <action>Exit workflow</action>
   </check>
 
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 <!-- ========================= -->
@@ -252,7 +252,7 @@ If the command targets a story, set `story_key={{next_story_id}}` when prompted.
   <template-output>risks = {{risks}}</template-output>
   <action>Return to caller</action>
 
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 <!-- ========================= -->
@@ -300,7 +300,7 @@ If the command targets a story, set `story_key={{next_story_id}}` when prompted.
 
 <template-output>is_valid = true</template-output>
 <template-output>message = "sprint-status.yaml valid: metadata complete, all statuses recognized"</template-output>
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/workflows/gametest/gds-e2e-scaffold/SKILL.md
+++ b/src/workflows/gametest/gds-e2e-scaffold/SKILL.md
@@ -22,7 +22,7 @@ description: 'Scaffold end-to-end testing infrastructure. Use when the user says
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -298,7 +298,7 @@ Tests/PlayMode/E2E/          (Unity)
 5. Use `automate` workflow to generate E2E tests from scenarios
 ```
   </action>
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/workflows/gametest/gds-performance-test/SKILL.md
+++ b/src/workflows/gametest/gds-performance-test/SKILL.md
@@ -22,7 +22,7 @@ description: 'Design game performance testing strategy. Use when the user says "
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -374,7 +374,7 @@ func test_performance_entity_stress():
   </action>
   <action>Load and apply `{validation}` checklist to verify all deliverables are complete</action>
   <action>Present a summary of what was produced and the recommended next steps to the user</action>
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/workflows/gametest/gds-playtest-plan/SKILL.md
+++ b/src/workflows/gametest/gds-playtest-plan/SKILL.md
@@ -19,7 +19,7 @@ description: 'Create structured playtesting plans for user feedback. Use when th
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -388,6 +388,6 @@ Refer to `checklist.md` for validation criteria.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/gametest/gds-test-automate/SKILL.md
+++ b/src/workflows/gametest/gds-test-automate/SKILL.md
@@ -22,7 +22,7 @@ description: 'Generate automated game tests for gameplay systems. Use when the u
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -383,7 +383,7 @@ public IEnumerator Smoke_NewGame_StartsSuccessfully()
   </action>
   <action>Load and apply `{validation}` checklist to verify all deliverables are complete</action>
   <action>Present the automation summary to the user</action>
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/workflows/gametest/gds-test-design/SKILL.md
+++ b/src/workflows/gametest/gds-test-design/SKILL.md
@@ -19,7 +19,7 @@ description: 'Create comprehensive game test scenarios. Use when the user says "
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -423,6 +423,6 @@ Refer to `checklist.md` for validation criteria.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/gametest/gds-test-framework/SKILL.md
+++ b/src/workflows/gametest/gds-test-framework/SKILL.md
@@ -19,7 +19,7 @@ description: 'Initialize game test framework for Unity, Unreal, or Godot. Use wh
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -437,6 +437,6 @@ Refer to `checklist.md` for comprehensive validation criteria.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/gametest/gds-test-review/SKILL.md
+++ b/src/workflows/gametest/gds-test-review/SKILL.md
@@ -19,7 +19,7 @@ description: 'Review test quality and coverage. Use when the user says "test rev
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 
@@ -358,6 +358,6 @@ Refer to `checklist.md` for validation criteria.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.

--- a/src/workflows/gds-document-project/SKILL.md
+++ b/src/workflows/gds-document-project/SKILL.md
@@ -31,7 +31,7 @@ description: 'Analyze existing game projects to produce useful documentation. Us
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/gds-document-project/instructions.md
+++ b/src/workflows/gds-document-project/instructions.md
@@ -215,7 +215,7 @@ Since no workflow is in progress:
 - Or run `workflow-init` to create a workflow path and get guided next steps
   {{/if}}
   </output>
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 </step>
 
 </workflow>

--- a/src/workflows/gds-document-project/workflows/deep-dive-instructions.md
+++ b/src/workflows/gds-document-project/workflows/deep-dive-instructions.md
@@ -290,7 +290,7 @@ These comprehensive docs are now ready for:
 
 Thank you for using the document-project workflow!
 </action>
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 <action>Exit workflow</action>
 </action>
 </step>

--- a/src/workflows/gds-document-project/workflows/full-scan-instructions.md
+++ b/src/workflows/gds-document-project/workflows/full-scan-instructions.md
@@ -1103,6 +1103,6 @@ When ready to plan new features, run the PRD workflow and provide this index as 
 
 <action>Display: "State file saved: {{output_folder}}/project-scan-report.json"</action>
 
-<action>Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
+<action>Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete` — if the resolved value is non-empty, follow it as the final terminal instruction before exiting.</action>
 
 </workflow>

--- a/src/workflows/gds-quick-flow/gds-quick-dev/SKILL.md
+++ b/src/workflows/gds-quick-flow/gds-quick-dev/SKILL.md
@@ -20,7 +20,7 @@ description: 'Implements any user intent, requirement, story, bug fix or change 
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/gds-quick-flow/gds-quick-dev/step-05-present.md
+++ b/src/workflows/gds-quick-flow/gds-quick-dev/step-05-present.md
@@ -73,6 +73,6 @@ Workflow complete.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolved `workflow.on_complete` is non-empty, follow it as the final terminal instruction before exiting.


### PR DESCRIPTION
Two ways this module needed a system Python it should not have needed.

## 1. The customization resolver — 61 invocations

Every agent and workflow shelled out to a bare `python3` to run `_bmad/scripts/resolve_customization.py`. That script declares `requires-python = ">=3.11"` and hard-exits below it, because `tomllib` is a 3.11 stdlib addition. On macOS without Homebrew or Ubuntu 22.04 — where `python3` is 3.10 — activation fell through to the "if the script fails" path and hand-merged the TOML in-context, with no error surfaced.

`uv run` reads the script's own `requires-python` and provisions a matching interpreter instead.

Also `gds-gdd/references/validation-render.md` → `render-validation-html.py`.

## 2. Browser openers — 4 sites

These spawned a Python interpreter purely to open an HTML file:

```
python3 -c "import webbrowser, pathlib; webbrowser.open(pathlib.Path('PATH').resolve().as_uri())"
```

Replaced with the platform opener the rest of BMad already uses — `open` (macOS), `xdg-open` (Linux), `start ""` (Windows), path double-quoted.

These were the last place the module assumed a system Python at all, and they failed silently on a machine that has none — which is now a supported configuration, since uv provisions its own interpreter. Each site also gained an explicit failure instruction: hand the user the path rather than cycling through the other two openers.

## Also

**README badge** corrected from `>=3.10` to `>=3.11` — it advertised a floor that cannot run the module.

## Verification

`npm test` passes (lint, markdownlint, prettier). No bare `python3` or `python` invocation remains anywhere in `src/`.

Part of an ecosystem-wide pass — the same fix is going into bmad-method, bmad-builder, creative-intelligence-suite, and test-architecture-enterprise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated the documented minimum Python version to 3.11.

* **Improvements**
  * Standardized workflow and agent command execution through the project’s environment runner for more consistent behavior.
  * Improved HTML report and preview opening across macOS, Linux, and Windows.
  * Added clearer fallback messaging with the generated report path when automatic opening fails.
  * Preserved headless-mode behavior and existing workflow fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->